### PR TITLE
Cnx79 modificar usuario interno

### DIFF
--- a/api-gateway/src/internal-users/dto/update-internal-user.dto.ts
+++ b/api-gateway/src/internal-users/dto/update-internal-user.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class UpdateInternalUserDto {
+  @IsOptional()
+  @IsString({ message: 'password must be a string' })
+  password: string;
+
+  @IsOptional()
+  @IsInt({ message: 'roleId must be a number' })
+  @IsNotEmpty({ message: 'roleId is required' })
+  roleId: number;
+}

--- a/api-gateway/src/internal-users/internal-users.controller.ts
+++ b/api-gateway/src/internal-users/internal-users.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Inject,
   Param,
+  Patch,
   Post,
   Query,
 } from '@nestjs/common';
@@ -17,6 +18,7 @@ import { AuthenticatedUser } from 'src/common/interfaces/authenticatedRequest.in
 import { NATS_SERVICE } from 'src/config';
 import { CreateInternalUserDto } from './dto/create-internal-user.dto';
 import { GetInternalUsersDto } from './dto/get-internal-users.dto';
+import { UpdateInternalUserDto } from './dto/update-internal-user.dto';
 
 @Controller('internal-users')
 export class InternalUsersController {
@@ -57,6 +59,26 @@ export class InternalUsersController {
   deleteInternalUser(@Param('id') id: string, @User() user: AuthenticatedUser) {
     return this.client
       .send('internal-users_delete', { id: +id, userId: user.id })
+      .pipe(
+        catchError((error) => {
+          throw new RpcException(error);
+        }),
+      );
+  }
+
+  @Patch(':id')
+  @AuthRoles([ROLES.ADMIN])
+  updateInternalUser(
+    @Param('id') id: string,
+    @Body() updateUserDto: UpdateInternalUserDto,
+    @User() user: AuthenticatedUser,
+  ) {
+    return this.client
+      .send('internal-users_update', {
+        userId: id,
+        ...updateUserDto,
+        authenticatedUserId: user.id,
+      })
       .pipe(
         catchError((error) => {
           throw new RpcException(error);

--- a/users/src/common/exceptions/user.exceptions.ts
+++ b/users/src/common/exceptions/user.exceptions.ts
@@ -36,11 +36,29 @@ export class UserNotAllowedToDeleteException extends RpcException {
   }
 }
 
+export class UserNotAllowedToUpdateException extends RpcException {
+  constructor(id: number) {
+    super({
+      status: 400,
+      message: `User with id ${id} is not allowed to update`,
+    });
+  }
+}
+
 export class UserNotAdminOrModeratorException extends RpcException {
   constructor(id: number) {
     super({
       status: 400,
       message: `User with id ${id} is not admin or moderator`,
+    });
+  }
+}
+
+export class RoleNotAdminOrModeratorException extends RpcException {
+  constructor(id: number) {
+    super({
+      status: 400,
+      message: `Role with id ${id} is not admin or moderator`,
     });
   }
 }
@@ -212,6 +230,15 @@ export class InvalidCurrentPasswordException extends RpcException {
     super({
       status: 400,
       message: 'Invalid current password',
+    });
+  }
+}
+
+export class RoleModificationException extends RpcException {
+  constructor(roleId: number) {
+    super({
+      status: 400,
+      message: `Role with id ${roleId} cannot be modified to a lower role`,
     });
   }
 }

--- a/users/src/internal-users/controller/internal-users.controller.ts
+++ b/users/src/internal-users/controller/internal-users.controller.ts
@@ -3,6 +3,7 @@ import { MessagePattern, Payload } from '@nestjs/microservices';
 import { CreateInternalUserDto } from '../dto/create-internal-user.dto';
 import { DeleteInternalUserDto } from '../dto/delete-internal-user.dto';
 import { GetInternalUsersDto } from '../dto/get-internal-users.dto';
+import { UpdateInternalUserDto } from '../dto/update-internal-user.dto';
 import { InternalUsersService } from '../service/internal-users.service';
 
 @Controller('internal-users')
@@ -41,5 +42,12 @@ export class InternalUsersController {
     @Payload() deleteInternalUserDto: DeleteInternalUserDto,
   ) {
     return this.internalUsersService.deleteInternalUser(deleteInternalUserDto);
+  }
+
+  @MessagePattern('internal-users_update')
+  async updateInternalUserRpc(
+    @Payload() updateInternalUserDto: UpdateInternalUserDto,
+  ) {
+    return this.internalUsersService.updateInternalUser(updateInternalUserDto);
   }
 }

--- a/users/src/internal-users/dto/update-internal-user.dto.ts
+++ b/users/src/internal-users/dto/update-internal-user.dto.ts
@@ -1,0 +1,35 @@
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class UpdateInternalUserDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: 'userId must be a number' },
+  )
+  userId: number;
+
+  @IsOptional()
+  @IsString({ message: 'password must be a string' })
+  password: string;
+
+  @IsOptional()
+  @IsInt({ message: 'roleId must be a number' })
+  @IsNotEmpty({ message: 'roleId is required' })
+  roleId: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: 'authenticatedUserId must be a number' },
+  )
+  authenticatedUserId: number;
+}

--- a/users/src/internal-users/internal-users.module.ts
+++ b/users/src/internal-users/internal-users.module.ts
@@ -11,6 +11,7 @@ import { CreateInternalUserUseCase } from './service/use-cases/create-internal-u
 import { DeleteInternalUserUseCase } from './service/use-cases/delete-internal-user.use-cases';
 import { GetInternalUserUseCases } from './service/use-cases/get-internal-user.use-cases';
 import { GetRolesByNamesUseCases } from './service/use-cases/get-roles-by-names.use-cases.dto';
+import { UpdateInternalUserUseCase } from './service/use-cases/update-internal-user.use-cases';
 
 @Module({
   imports: [UsersModule, TypeOrmModule.forFeature([User, Role])],
@@ -18,11 +19,13 @@ import { GetRolesByNamesUseCases } from './service/use-cases/get-roles-by-names.
   providers: [
     InternalUsersService,
     CreateInternalUserUseCase,
-    UserBaseService,
     InternalUserRepository,
     GetRolesByNamesUseCases,
     GetInternalUserUseCases,
+    UpdateInternalUserUseCase,
+    UserBaseService,
     DeleteInternalUserUseCase,
   ],
+  exports: [],
 })
 export class InternalUsersModule {}

--- a/users/src/internal-users/repository/internal-user.repository.ts
+++ b/users/src/internal-users/repository/internal-user.repository.ts
@@ -22,6 +22,13 @@ export class InternalUserRepository extends UserRepository {
     });
   }
 
+  async findByIdWithRole(id: number) {
+    return this.userRepository.findOne({
+      where: { id },
+      relations: ['role'],
+    });
+  }
+
   async findRolesByNames(names: RoleName[]) {
     return this.userRepository.manager.find(Role, {
       where: { name: In(names) },
@@ -84,5 +91,9 @@ export class InternalUserRepository extends UserRepository {
 
   async deleteInternalUser(id: number) {
     return this.userRepository.softDelete(id);
+  }
+
+  async update(id: number, user: Partial<User>): Promise<User> {
+    return super.update(id, user);
   }
 }

--- a/users/src/internal-users/service/internal-users.service.ts
+++ b/users/src/internal-users/service/internal-users.service.ts
@@ -2,11 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { RoleName, ROLES } from 'src/common/constants/roles';
 import { DeleteInternalUserDto } from '../dto/delete-internal-user.dto';
 import { GetInternalUsersDto } from '../dto/get-internal-users.dto';
+import { UpdateInternalUserDto } from '../dto/update-internal-user.dto';
 import { CreateInternalUserUseCase } from './use-cases/create-internal-user.use-cases';
 import { DeleteInternalUserUseCase } from './use-cases/delete-internal-user.use-cases';
 import { GetInternalUserUseCases } from './use-cases/get-internal-user.use-cases';
 import { GetRolesByNamesUseCases } from './use-cases/get-roles-by-names.use-cases.dto';
-
+import { UpdateInternalUserUseCase } from './use-cases/update-internal-user.use-cases';
 interface CreateInternalUserDto {
   email: string;
   password: string;
@@ -20,6 +21,7 @@ export class InternalUsersService {
     private readonly getRolesByNamesUseCases: GetRolesByNamesUseCases,
     private readonly getInternalUserUseCases: GetInternalUserUseCases,
     private readonly deleteInternalUserUseCase: DeleteInternalUserUseCase,
+    private readonly updateInternalUserUseCase: UpdateInternalUserUseCase,
   ) {}
 
   async createInternalUser(createUserDto: CreateInternalUserDto) {
@@ -45,6 +47,13 @@ export class InternalUsersService {
     return this.deleteInternalUserUseCase.execute(
       deleteInternalUserDto.id,
       deleteInternalUserDto.userId,
+    );
+  }
+
+  async updateInternalUser(updateInternalUserDto: UpdateInternalUserDto) {
+    return this.updateInternalUserUseCase.execute(
+      updateInternalUserDto.userId,
+      updateInternalUserDto,
     );
   }
 }

--- a/users/src/internal-users/service/use-cases/update-internal-user.use-cases.ts
+++ b/users/src/internal-users/service/use-cases/update-internal-user.use-cases.ts
@@ -36,6 +36,12 @@ export class UpdateInternalUserUseCase {
       throw new UserNotAdminOrModeratorException(userId);
     }
 
+    // Validar que la contraseña no sea la misma que la actual
+    await this.userBaseService.validateNewPasswordNotSameAsCurrent(
+      user,
+      updateUserDto.password,
+    );
+
     let userToUpdate = { ...user };
 
     // Actualizar contraseña si se proporciona

--- a/users/src/internal-users/service/use-cases/update-internal-user.use-cases.ts
+++ b/users/src/internal-users/service/use-cases/update-internal-user.use-cases.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import {
+  RoleIdNotFoundException,
+  RoleModificationException,
+  RoleNotAdminOrModeratorException,
+  UserNotAdminOrModeratorException,
+  UserNotAllowedToUpdateException,
+  UserNotFoundByIdException,
+} from 'src/common/exceptions/user.exceptions';
+import { UserBaseService } from 'src/common/services/user-base.service';
+import { UpdateInternalUserDto } from 'src/internal-users/dto/update-internal-user.dto';
+import { InternalUserRepository } from 'src/internal-users/repository/internal-user.repository';
+import { ROLES } from 'src/users/constants/roles';
+
+@Injectable()
+export class UpdateInternalUserUseCase {
+  constructor(
+    private readonly userBaseService: UserBaseService,
+    private readonly internalUsersRepository: InternalUserRepository,
+  ) {}
+
+  async execute(userId: number, updateUserDto: UpdateInternalUserDto) {
+    // Validar que el usuario no se actualice a sí mismo
+    if (updateUserDto.authenticatedUserId === userId) {
+      throw new UserNotAllowedToUpdateException(userId);
+    }
+
+    // Validar que el usuario exista
+    const user = await this.internalUsersRepository.findByIdWithRole(userId);
+    if (!user) {
+      throw new UserNotFoundByIdException(userId);
+    }
+
+    // Validar que el rol del usuario sea admin o moderator
+    if (user.role.name !== ROLES.ADMIN && user.role.name !== ROLES.MODERATOR) {
+      throw new UserNotAdminOrModeratorException(userId);
+    }
+
+    let userToUpdate = { ...user };
+
+    // Actualizar contraseña si se proporciona
+    if (updateUserDto.password) {
+      userToUpdate = await this.userBaseService.prepareUserForUpdatePassword(
+        userToUpdate,
+        updateUserDto.password,
+      );
+    }
+
+    // Validar y actualizar rol si se proporciona
+    if (updateUserDto.roleId) {
+      const newRole = await this.internalUsersRepository.findRoleById(
+        updateUserDto.roleId,
+      );
+      if (!newRole) {
+        throw new RoleIdNotFoundException(updateUserDto.roleId);
+      }
+
+      // Validar que el rol sea admin o moderator
+      if (newRole.name !== ROLES.ADMIN && newRole.name !== ROLES.MODERATOR) {
+        throw new RoleNotAdminOrModeratorException(newRole.id);
+      }
+
+      // Obtener el rol actual del usuario
+      const currentRole = await this.internalUsersRepository.findRoleById(
+        user.roleId,
+      );
+      if (!currentRole) {
+        throw new RoleIdNotFoundException(user.roleId);
+      }
+
+      // Validar que el rol no se modifique de manera descendente (admin -> moderator)
+      if (
+        newRole.name === ROLES.MODERATOR &&
+        currentRole.name === ROLES.ADMIN
+      ) {
+        throw new RoleModificationException(updateUserDto.roleId);
+      }
+
+      // Actualizar el roleId en el objeto userToUpdate
+      userToUpdate.roleId = updateUserDto.roleId;
+    }
+
+    const userUpdated = await this.internalUsersRepository.update(
+      userId,
+      userToUpdate,
+    );
+
+    return {
+      id: userUpdated.id,
+      email: userUpdated.email,
+      roleId: userUpdated.roleId,
+      roleName: userUpdated.role.name,
+    };
+  }
+}


### PR DESCRIPTION
# 🛠 Update Internal User Functionality

## Description

This PR adds secure and validated functionality for updating internal users, including:

- Role-based restrictions for who can be updated and how
- Validation to avoid self-updates
- Role hierarchy checks (e.g. prevent downgrade from admin to moderator)
- Password change with protection against reusing current password
- Full audit-friendly design with custom exceptions

## Changes

- Added `UpdateInternalUserDto` with class-validator rules
- Created `UpdateInternalUserUseCase` with full update and validation logic
- Implemented `updateInternalUserRpc` message handler
- Added custom exceptions:
  - `UserNotAllowedToUpdateException`
  - `UserNotAdminOrModeratorException`
  - `RoleNotAdminOrModeratorException`
  - `RoleModificationException`
- Added route `PATCH /internal-users/:id` protected by `AuthRoles([ADMIN])`

## Technical Details

- Prevents user from updating their own role/password
- Requires updated roles to be either `ADMIN` or `MODERATOR`
- Blocks downgrading from `ADMIN` to `MODERATOR`
- Ensures password change is effective (not identical to current)
- Uses repository `findByIdWithRole` and `update`

## Security

- JWT + role-based protection
- Prevents privilege escalation or unintended downgrades
- Custom exception-driven flow to ensure safety and traceability

---

# 🔒 Implementación de Actualización de Usuarios Internos

## Descripción

Este PR implementa la funcionalidad para modificar usuarios internos de forma segura y validada, incluyendo:

- Restricciones basadas en rol (solo ADMIN puede modificar)
- Prevención de auto-modificación
- Verificación de jerarquía de roles (no se puede degradar de admin a moderador)
- Cambio de contraseña con validación frente a la actual
- Lógica robusta y clara mediante excepciones personalizadas

## Cambios

- Se crea `UpdateInternalUserDto` con validaciones usando `class-validator`
- Nuevo `UpdateInternalUserUseCase` con flujo completo de actualización
- Handler `internal-users_update` agregado para NATS
- Excepciones personalizadas:
  - `UserNotAllowedToUpdateException`
  - `UserNotAdminOrModeratorException`
  - `RoleNotAdminOrModeratorException`
  - `RoleModificationException`
- Endpoint `PATCH /internal-users/:id` con `@AuthRoles([ADMIN])`

## Detalles Técnicos

- Impide que un usuario se modifique a sí mismo
- El nuevo rol debe ser `ADMIN` o `MODERATOR`
- Bloquea cambios de `ADMIN` a `MODERATOR`
- Asegura que la nueva contraseña sea diferente
- Uso de métodos `findByIdWithRole` y `update` desde el repositorio

## Seguridad

- Protegido por JWT y verificación de roles
- Previene escaladas o caídas de privilegios accidentales
- Manejo explícito de errores y validaciones seguras
