### PR TITLE
feat: add quotation validity days and time unit to service hiring and service DTOs

### DIFF
--- a/api-gateway/src/service-hirings/dto/create-quotation.dto.ts
+++ b/api-gateway/src/service-hirings/dto/create-quotation.dto.ts
@@ -22,4 +22,9 @@ export class CreateQuotationDto {
   @IsString()
   @MaxLength(1000)
   quotationNotes?: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(1, { message: 'quotationValidityDays must be at least 1 day' })
+  quotationValidityDays: number;
 }

--- a/api-gateway/src/services/dto/create-service.dto.ts
+++ b/api-gateway/src/services/dto/create-service.dto.ts
@@ -2,6 +2,7 @@ import { Transform } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
+  IsEnum,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -10,6 +11,7 @@ import {
   MaxLength,
   Min,
 } from 'class-validator';
+import { TimeUnit } from './time-unit.enum';
 
 export class CreateServiceDto {
   @IsString()
@@ -40,6 +42,12 @@ export class CreateServiceDto {
   @IsNumber()
   @Min(1, { message: 'estimatedHours must be greater than or equal to 1 hour' })
   estimatedHours?: number;
+
+  @IsNotEmpty()
+  @IsEnum(TimeUnit, {
+    message: 'timeUnit must be a valid time unit (hours, days, weeks)',
+  })
+  timeUnit: TimeUnit;
 
   @IsOptional()
   @IsArray()

--- a/api-gateway/src/services/dto/index.ts
+++ b/api-gateway/src/services/dto/index.ts
@@ -4,4 +4,5 @@ export * from './get-service-by-id.dto';
 export * from './get-services-by-user.dto';
 export * from './get-services.dto';
 export * from './service-id.dto';
+export * from './time-unit.enum';
 export * from './update-service.dto';

--- a/api-gateway/src/services/dto/time-unit.enum.ts
+++ b/api-gateway/src/services/dto/time-unit.enum.ts
@@ -1,0 +1,5 @@
+export enum TimeUnit {
+  HOURS = 'hours',
+  DAYS = 'days',
+  WEEKS = 'weeks',
+}

--- a/api-gateway/src/services/dto/update-service.dto.ts
+++ b/api-gateway/src/services/dto/update-service.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
-import { IsNumber, IsOptional, Min, ValidateIf } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, Min, ValidateIf } from 'class-validator';
+import { TimeUnit } from './time-unit.enum';
 
 export class UpdateServiceDto {
   @IsOptional()
@@ -19,4 +20,8 @@ export class UpdateServiceDto {
   @IsNumber({}, { message: 'estimatedHours must be a number' })
   @Min(1, { message: 'estimatedHours must be greater than or equal to 1 hour' })
   estimatedHours?: number | null;
+
+  @IsOptional()
+  @IsEnum(TimeUnit)
+  timeUnit?: TimeUnit;
 }

--- a/api-gateway/src/services/services.controller.ts
+++ b/api-gateway/src/services/services.controller.ts
@@ -171,6 +171,7 @@ export class ServicesController {
         userId: user.id,
         price: updateServiceDto.price,
         estimatedHours: updateServiceDto.estimatedHours,
+        timeUnit: updateServiceDto.timeUnit,
       })
       .pipe(
         catchError((error) => {

--- a/services/postgres-init/04-add-improvements.sql
+++ b/services/postgres-init/04-add-improvements.sql
@@ -1,0 +1,35 @@
+-- Migration: Add improvements to services module
+-- Date: 2025-09-30
+-- Note: timeUnit column will be created by TypeORM synchronize, we just populate existing NULL values
+
+-- Create ENUM type for time units if it doesn't exist (TypeORM will use this)
+DO $$ BEGIN
+    CREATE TYPE "services_timeunit_enum" AS ENUM ('hours', 'days', 'weeks');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- Update any existing NULL timeUnit values to default 'hours'
+-- This will run after TypeORM creates the column
+UPDATE services SET "timeUnit" = 'hours' WHERE "timeUnit" IS NULL;
+
+-- Add quotationValidityDays column to service_hirings table if it doesn't exist
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'service_hirings' AND column_name = 'quotationValidityDays') THEN
+        ALTER TABLE service_hirings ADD COLUMN "quotationValidityDays" INTEGER NULL;
+    END IF;
+END $$;
+
+-- Add expired status to service_hiring_statuses if it doesn't exist
+INSERT INTO service_hiring_statuses (name, code, description) 
+SELECT 'Vencida', 'expired', 'Cotización vencida por tiempo límite'
+WHERE NOT EXISTS (
+    SELECT 1 FROM service_hiring_statuses WHERE code = 'expired'
+);
+
+-- Additional safety update for any remaining NULL values (redundant but safe)
+UPDATE services 
+SET "timeUnit" = 'hours'::time_unit_enum
+WHERE "timeUnit" IS NULL;

--- a/services/src/common/utils/service-transform.utils.ts
+++ b/services/src/common/utils/service-transform.utils.ts
@@ -1,4 +1,5 @@
 import { Service } from '../../services/entities/service.entity';
+import { TimeUnit } from '../../services/enums/time-unit.enum';
 
 export interface TransformedService {
   id: number;
@@ -6,9 +7,12 @@ export interface TransformedService {
   description: string;
   price: number;
   estimatedHours?: number | null;
+  timeUnit: TimeUnit | null;
   images?: string[];
   status: string;
   isActive: boolean;
+  hasPendingQuotation?: boolean;
+  hasActiveQuotation?: boolean;
   createdAt: Date;
   updatedAt: Date;
   category: {
@@ -30,10 +34,12 @@ export function transformServicesWithOwners(
   services: Service[],
   users: any[],
   currentUserId?: number,
+  quotationInfo?: Map<number, { hasPending: boolean; hasActive: boolean }>,
 ): TransformedService[] {
   return services.map((service) => {
     const owner = users.find((user) => user.id === service.userId);
     const isOwner = currentUserId === service.userId;
+    const quotationData = quotationInfo?.get(service.id);
 
     return {
       id: service.id,
@@ -41,9 +47,12 @@ export function transformServicesWithOwners(
       description: service.description,
       price: service.price,
       estimatedHours: service.estimatedHours,
+      timeUnit: service.timeUnit || TimeUnit.HOURS,
       images: service.images,
       status: service.status,
       isActive: service.status === 'active',
+      hasPendingQuotation: quotationData?.hasPending || false,
+      hasActiveQuotation: quotationData?.hasActive || false,
       createdAt: service.createdAt,
       updatedAt: service.updatedAt,
       category: {

--- a/services/src/service-hirings/dto/create-quotation.dto.ts
+++ b/services/src/service-hirings/dto/create-quotation.dto.ts
@@ -22,4 +22,9 @@ export class CreateQuotationDto {
   @IsString()
   @MaxLength(1000)
   quotationNotes?: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(1, { message: 'quotationValidityDays must be at least 1 day' })
+  quotationValidityDays: number;
 }

--- a/services/src/service-hirings/entities/service-hiring.entity.ts
+++ b/services/src/service-hirings/entities/service-hiring.entity.ts
@@ -42,6 +42,9 @@ export class ServiceHiring {
   @Column({ type: 'timestamp', nullable: true })
   respondedAt: Date;
 
+  @Column({ type: 'int', nullable: true })
+  quotationValidityDays: number;
+
   @ManyToOne(() => ServiceHiringStatus)
   @JoinColumn({ name: 'status_id' })
   status: ServiceHiringStatus;

--- a/services/src/service-hirings/enums/service-hiring-status.enum.ts
+++ b/services/src/service-hirings/enums/service-hiring-status.enum.ts
@@ -7,4 +7,5 @@ export enum ServiceHiringStatusCode {
   IN_PROGRESS = 'in_progress',
   COMPLETED = 'completed',
   NEGOTIATING = 'negotiating',
+  EXPIRED = 'expired',
 }

--- a/services/src/service-hirings/service-hirings.module.ts
+++ b/services/src/service-hirings/service-hirings.module.ts
@@ -7,6 +7,7 @@ import { ServiceHiringStatus } from './entities/service-hiring-status.entity';
 import { ServiceHiring } from './entities/service-hiring.entity';
 import { ServiceHiringStatusRepository } from './repositories/service-hiring-status.repository';
 import { ServiceHiringRepository } from './repositories/service-hiring.repository';
+import { QuotationExpirationService } from './services/quotation-expiration.service';
 import { ServiceHiringOperationsService } from './services/service-hiring-operations.service';
 import { ServiceHiringStatusService } from './services/service-hiring-status.service';
 import { ServiceHiringTransformService } from './services/service-hiring-transform.service';
@@ -45,6 +46,7 @@ import { ServiceHiringStateFactory } from './states/service-hiring-state.factory
     ServiceHiringOperationsService,
     ServiceHiringTransformService,
     ServiceHiringStateFactory,
+    QuotationExpirationService,
   ],
   imports: [
     TypeOrmModule.forFeature([ServiceHiring, ServiceHiringStatus]),

--- a/services/src/service-hirings/services/quotation-expiration.service.ts
+++ b/services/src/service-hirings/services/quotation-expiration.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { ServiceHiringStatusCode } from '../enums/service-hiring-status.enum';
+import { ServiceHiringRepository } from '../repositories/service-hiring.repository';
+import { ServiceHiringStatusService } from './service-hiring-status.service';
+
+@Injectable()
+export class QuotationExpirationService {
+  constructor(
+    private readonly hiringRepository: ServiceHiringRepository,
+    private readonly statusService: ServiceHiringStatusService,
+  ) {}
+
+  async checkExpiredQuotations() {
+    console.log('Checking for expired quotations...');
+
+    try {
+      // Obtener el estado "expired"
+      const expiredStatus = await this.statusService.getStatusByCode(
+        ServiceHiringStatusCode.EXPIRED,
+      );
+
+      // Ejecutar la actualización directamente en la base de datos
+      const result = await this.hiringRepository.markExpiredQuotations(
+        expiredStatus.id,
+      );
+
+      if (result > 0) {
+        console.log(`Marked ${result} quotations as expired`);
+      }
+
+      return result;
+    } catch (error) {
+      console.error('Error checking expired quotations:', error);
+      return 0;
+    }
+  }
+
+  async isQuotationExpired(hiringId: number): Promise<boolean> {
+    const hiring = await this.hiringRepository.findById(hiringId);
+
+    if (!hiring || !hiring.quotedAt || !hiring.quotationValidityDays) {
+      return false;
+    }
+
+    const expirationDate = new Date(hiring.quotedAt);
+    expirationDate.setDate(
+      expirationDate.getDate() + hiring.quotationValidityDays,
+    );
+
+    return new Date() > expirationDate;
+  }
+}

--- a/services/src/service-hirings/services/service-hiring-operations.service.ts
+++ b/services/src/service-hirings/services/service-hiring-operations.service.ts
@@ -2,17 +2,37 @@ import { Injectable } from '@nestjs/common';
 import { ServiceHiring } from '../entities/service-hiring.entity';
 import { ServiceHiringContext } from '../states/service-hiring-context';
 import { ServiceHiringStateFactory } from '../states/service-hiring-state.factory';
+import { QuotationExpirationService } from './quotation-expiration.service';
 
 @Injectable()
 export class ServiceHiringOperationsService {
-  constructor(private readonly stateFactory: ServiceHiringStateFactory) {}
+  constructor(
+    private readonly stateFactory: ServiceHiringStateFactory,
+    private readonly quotationExpirationService: QuotationExpirationService,
+  ) {}
 
   getHiringContext(hiring: ServiceHiring): ServiceHiringContext {
     const state = this.stateFactory.createState(hiring);
     return new ServiceHiringContext(hiring, state);
   }
 
-  canPerformAction(hiring: ServiceHiring, action: string): boolean {
+  async canPerformAction(
+    hiring: ServiceHiring,
+    action: string,
+  ): Promise<boolean> {
+    // Verificar si la cotización está vencida
+    const isExpired = await this.quotationExpirationService.isQuotationExpired(
+      hiring.id,
+    );
+
+    // Si está vencida, solo se puede ver (no permitir acciones)
+    if (
+      isExpired &&
+      ['accept', 'reject', 'edit', 'negotiate'].includes(action)
+    ) {
+      return false;
+    }
+
     const context = this.getHiringContext(hiring);
 
     switch (action) {
@@ -33,7 +53,17 @@ export class ServiceHiringOperationsService {
     }
   }
 
-  getAvailableActions(hiring: ServiceHiring): string[] {
+  async getAvailableActions(hiring: ServiceHiring): Promise<string[]> {
+    // Verificar si la cotización está vencida
+    const isExpired = await this.quotationExpirationService.isQuotationExpired(
+      hiring.id,
+    );
+
+    // Si está vencida, solo se puede ver
+    if (isExpired) {
+      return ['view'];
+    }
+
     const context = this.getHiringContext(hiring);
     return context.getAvailableActions();
   }

--- a/services/src/service-hirings/services/service-hiring-transform.service.ts
+++ b/services/src/service-hirings/services/service-hiring-transform.service.ts
@@ -3,6 +3,7 @@ import {
   PaginationInfo,
   calculatePagination,
 } from '../../common/utils/pagination.utils';
+import { TimeUnit } from '../../services/enums/time-unit.enum';
 import { GetServiceHiringsDto } from '../dto';
 import { ServiceHiring } from '../entities/service-hiring.entity';
 
@@ -10,12 +11,16 @@ export interface ServiceHiringResponse {
   id: number;
   serviceId: number;
   userId: number;
+  name?: string;
+  lastName?: string;
   description: string;
   quotedPrice?: number;
   estimatedHours?: number;
   quotationNotes?: string;
   quotedAt?: Date;
   respondedAt?: Date;
+  quotationValidityDays?: number;
+  isExpired?: boolean;
   status: {
     id: number;
     name: string;
@@ -26,6 +31,7 @@ export interface ServiceHiringResponse {
     title: string;
     description: string;
     price: number;
+    timeUnit: TimeUnit | null;
     images?: string[];
   };
   createdAt: Date;
@@ -43,17 +49,24 @@ export class ServiceHiringTransformService {
   transformToResponse(
     hiring: ServiceHiring,
     availableActions: string[] = [],
+    user?: any,
   ): ServiceHiringResponse {
+    const isExpired = this.isQuotationExpired(hiring);
+
     return {
       id: hiring.id,
       serviceId: hiring.serviceId,
       userId: hiring.userId,
+      name: user?.profile?.name,
+      lastName: user?.profile?.lastName,
       description: hiring.description,
       quotedPrice: hiring.quotedPrice,
       estimatedHours: hiring.estimatedHours,
       quotationNotes: hiring.quotationNotes,
       quotedAt: hiring.quotedAt,
       respondedAt: hiring.respondedAt,
+      quotationValidityDays: hiring.quotationValidityDays,
+      isExpired,
       status: {
         id: hiring.status.id,
         name: hiring.status.name,
@@ -64,6 +77,7 @@ export class ServiceHiringTransformService {
         title: hiring.service.title,
         description: hiring.service.description,
         price: hiring.service.price,
+        timeUnit: hiring.service.timeUnit || TimeUnit.HOURS,
         images: hiring.service.images,
       },
       createdAt: hiring.createdAt,
@@ -72,16 +86,31 @@ export class ServiceHiringTransformService {
     };
   }
 
+  private isQuotationExpired(hiring: ServiceHiring): boolean {
+    if (!hiring.quotedAt || !hiring.quotationValidityDays) {
+      return false;
+    }
+
+    const expirationDate = new Date(hiring.quotedAt);
+    expirationDate.setDate(
+      expirationDate.getDate() + hiring.quotationValidityDays,
+    );
+
+    return new Date() > expirationDate;
+  }
+
   transformToListResponse(
     hirings: ServiceHiring[],
     total: number,
     params: GetServiceHiringsDto,
     availableActionsMap: Map<number, string[]> = new Map(),
+    usersMap?: Map<number, any>,
   ): ServiceHiringListResponse {
     const data = hirings.map((hiring) =>
       this.transformToResponse(
         hiring,
         availableActionsMap.get(hiring.id) || [],
+        usersMap?.get(hiring.userId),
       ),
     );
 

--- a/services/src/service-hirings/services/use-cases/accept-service-hiring.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/accept-service-hiring.use-case.ts
@@ -30,7 +30,7 @@ export class AcceptServiceHiringUseCase {
     }
 
     // Validar que se puede aceptar
-    if (!this.operationsService.canPerformAction(hiring, 'accept')) {
+    if (!(await this.operationsService.canPerformAction(hiring, 'accept'))) {
       throw new RpcException(
         'No se puede aceptar esta contratación en su estado actual',
       );

--- a/services/src/service-hirings/services/use-cases/cancel-service-hiring.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/cancel-service-hiring.use-case.ts
@@ -30,7 +30,7 @@ export class CancelServiceHiringUseCase {
     }
 
     // Validar que se puede cancelar
-    if (!this.operationsService.canPerformAction(hiring, 'cancel')) {
+    if (!(await this.operationsService.canPerformAction(hiring, 'cancel'))) {
       throw new RpcException(
         'No se puede cancelar esta contratación en su estado actual',
       );

--- a/services/src/service-hirings/services/use-cases/create-quotation.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/create-quotation.use-case.ts
@@ -40,7 +40,7 @@ export class CreateQuotationUseCase {
     }
 
     // Validar que se puede cotizar
-    if (!this.operationsService.canPerformAction(hiring, 'quote')) {
+    if (!(await this.operationsService.canPerformAction(hiring, 'quote'))) {
       throw new RpcException(
         'No se puede cotizar esta contratación en su estado actual',
       );
@@ -62,6 +62,7 @@ export class CreateQuotationUseCase {
       quotedPrice: quotationDto.quotedPrice,
       estimatedHours: quotationDto.estimatedHours,
       quotationNotes: quotationDto.quotationNotes,
+      quotationValidityDays: quotationDto.quotationValidityDays,
       quotedAt: new Date(),
       statusId: quotedStatus.id,
     });

--- a/services/src/service-hirings/services/use-cases/edit-quotation.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/edit-quotation.use-case.ts
@@ -35,7 +35,7 @@ export class EditQuotationUseCase {
     }
 
     // Validar que se puede editar la cotización
-    if (!this.operationsService.canPerformAction(hiring, 'edit')) {
+    if (!(await this.operationsService.canPerformAction(hiring, 'edit'))) {
       throw new RpcException(
         'No se puede editar esta cotización en su estado actual',
       );
@@ -52,6 +52,7 @@ export class EditQuotationUseCase {
       quotedPrice: quotationDto.quotedPrice,
       estimatedHours: quotationDto.estimatedHours,
       quotationNotes: quotationDto.quotationNotes,
+      quotationValidityDays: quotationDto.quotationValidityDays,
       quotedAt: new Date(),
     });
 

--- a/services/src/service-hirings/services/use-cases/get-service-hirings-by-service-owner.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/get-service-hirings-by-service-owner.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { UsersClientService } from '../../../common/services/users-client.service';
 import { GetServiceHiringsDto } from '../../dto';
 import { ServiceHiringRepository } from '../../repositories/service-hiring.repository';
 import { ServiceHiringOperationsService } from '../service-hiring-operations.service';
@@ -10,24 +11,33 @@ export class GetServiceHiringsByServiceOwnerUseCase {
     private readonly hiringRepository: ServiceHiringRepository,
     private readonly operationsService: ServiceHiringOperationsService,
     private readonly transformService: ServiceHiringTransformService,
+    private readonly usersClientService: UsersClientService,
   ) {}
 
   async execute(serviceOwnerId: number, params: GetServiceHiringsDto) {
     const { data: hirings, total } =
       await this.hiringRepository.findByServiceOwner(serviceOwnerId, params);
 
+    // Obtener IDs únicos de usuarios
+    const userIds = [...new Set(hirings.map((hiring) => hiring.userId))];
+
+    // Obtener información de usuarios
+    const users = await this.usersClientService.getUsersByIds(userIds);
+    const usersMap = new Map(users.map((user) => [user.id, user]));
+
     // Obtener acciones disponibles para cada contratación
     const availableActionsMap = new Map<number, string[]>();
-    hirings.forEach((hiring) => {
-      const actions = this.operationsService.getAvailableActions(hiring);
+    for (const hiring of hirings) {
+      const actions = await this.operationsService.getAvailableActions(hiring);
       availableActionsMap.set(hiring.id, actions);
-    });
+    }
 
     return this.transformService.transformToListResponse(
       hirings,
       total,
       params,
       availableActionsMap,
+      usersMap,
     );
   }
 }

--- a/services/src/service-hirings/services/use-cases/get-service-hirings-by-user.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/get-service-hirings-by-user.use-case.ts
@@ -19,10 +19,10 @@ export class GetServiceHiringsByUserUseCase {
 
     // Obtener acciones disponibles para cada contratación
     const availableActionsMap = new Map<number, string[]>();
-    hirings.forEach((hiring) => {
-      const actions = this.operationsService.getAvailableActions(hiring);
+    for (const hiring of hirings) {
+      const actions = await this.operationsService.getAvailableActions(hiring);
       availableActionsMap.set(hiring.id, actions);
-    });
+    }
 
     return this.transformService.transformToListResponse(
       hirings,

--- a/services/src/service-hirings/services/use-cases/get-service-hirings.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/get-service-hirings.use-case.ts
@@ -18,10 +18,10 @@ export class GetServiceHiringsUseCase {
 
     // Obtener acciones disponibles para cada contratación
     const availableActionsMap = new Map<number, string[]>();
-    hirings.forEach((hiring) => {
-      const actions = this.operationsService.getAvailableActions(hiring);
+    for (const hiring of hirings) {
+      const actions = await this.operationsService.getAvailableActions(hiring);
       availableActionsMap.set(hiring.id, actions);
-    });
+    }
 
     return this.transformService.transformToListResponse(
       hirings,

--- a/services/src/service-hirings/services/use-cases/negotiate-service-hiring.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/negotiate-service-hiring.use-case.ts
@@ -30,7 +30,7 @@ export class NegotiateServiceHiringUseCase {
     }
 
     // Validar que se puede negociar
-    if (!this.operationsService.canPerformAction(hiring, 'negotiate')) {
+    if (!(await this.operationsService.canPerformAction(hiring, 'negotiate'))) {
       throw new RpcException(
         'No se puede negociar esta contratación en su estado actual',
       );

--- a/services/src/service-hirings/services/use-cases/reject-service-hiring.use-case.ts
+++ b/services/src/service-hirings/services/use-cases/reject-service-hiring.use-case.ts
@@ -30,7 +30,7 @@ export class RejectServiceHiringUseCase {
     }
 
     // Validar que se puede rechazar
-    if (!this.operationsService.canPerformAction(hiring, 'reject')) {
+    if (!(await this.operationsService.canPerformAction(hiring, 'reject'))) {
       throw new RpcException(
         'No se puede rechazar esta contratación en su estado actual',
       );

--- a/services/src/services/controllers/services.controller.ts
+++ b/services/src/services/controllers/services.controller.ts
@@ -103,13 +103,18 @@ export class ServicesController {
       userId: number;
       price?: number;
       estimatedHours?: number | null;
+      timeUnit?: string;
     },
   ) {
     try {
       const result = await this.servicesService.updateService(
         data.serviceId,
         data.userId,
-        { price: data.price, estimatedHours: data.estimatedHours },
+        {
+          price: data.price,
+          estimatedHours: data.estimatedHours,
+          timeUnit: data.timeUnit as any,
+        },
       );
       return result;
     } catch (error) {

--- a/services/src/services/dto/create-service.dto.ts
+++ b/services/src/services/dto/create-service.dto.ts
@@ -1,6 +1,7 @@
 import {
   ArrayMaxSize,
   IsArray,
+  IsEnum,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -9,6 +10,7 @@ import {
   MaxLength,
   Min,
 } from 'class-validator';
+import { TimeUnit } from '../enums/time-unit.enum';
 
 export class CreateServiceDto {
   @IsString()
@@ -34,6 +36,12 @@ export class CreateServiceDto {
   @IsNumber()
   @Min(1, { message: 'estimatedHours must be greater than or equal to 1 hour' })
   estimatedHours?: number;
+
+  @IsNotEmpty()
+  @IsEnum(TimeUnit, {
+    message: 'timeUnit must be a valid time unit (hours, days, weeks)',
+  })
+  timeUnit: TimeUnit;
 
   @IsOptional()
   @IsArray()

--- a/services/src/services/dto/update-service.dto.ts
+++ b/services/src/services/dto/update-service.dto.ts
@@ -1,4 +1,5 @@
-import { IsNumber, IsOptional, IsPositive } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsPositive } from 'class-validator';
+import { TimeUnit } from '../enums/time-unit.enum';
 
 export class UpdateServiceDto {
   @IsOptional()
@@ -10,4 +11,10 @@ export class UpdateServiceDto {
   @IsNumber({}, { message: 'Las horas estimadas deben ser un número válido' })
   @IsPositive({ message: 'Las horas estimadas deben ser mayor a 0' })
   estimatedHours?: number;
+
+  @IsOptional()
+  @IsEnum(TimeUnit, {
+    message: 'La unidad de tiempo debe ser hours, days o weeks',
+  })
+  timeUnit?: TimeUnit;
 }

--- a/services/src/services/entities/service.entity.ts
+++ b/services/src/services/entities/service.entity.ts
@@ -7,6 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { TimeUnit } from '../enums/time-unit.enum';
 import { ServiceCategory } from './category.entity';
 
 @Entity('services')
@@ -32,6 +33,9 @@ export class Service {
 
   @Column({ type: 'int', nullable: true })
   estimatedHours: number | null;
+
+  @Column({ type: 'enum', enum: TimeUnit, nullable: true, default: 'hours' })
+  timeUnit: TimeUnit | null;
 
   @Column({ type: 'json', nullable: true })
   images: string[];

--- a/services/src/services/enums/index.ts
+++ b/services/src/services/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './time-unit.enum';

--- a/services/src/services/enums/time-unit.enum.ts
+++ b/services/src/services/enums/time-unit.enum.ts
@@ -1,0 +1,5 @@
+export enum TimeUnit {
+  HOURS = 'hours',
+  DAYS = 'days',
+  WEEKS = 'weeks',
+}

--- a/services/src/services/index.ts
+++ b/services/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from './controllers';
 export * from './dto';
 export * from './entities';
+export * from './enums';
 export * from './repositories';
 export * from './services';
 export * from './services.module';

--- a/services/src/services/services/services.service.ts
+++ b/services/src/services/services/services.service.ts
@@ -7,6 +7,7 @@ import {
   ServiceCategoryResponseDto,
 } from '../dto';
 import { Service } from '../entities/service.entity';
+import { TimeUnit } from '../enums/time-unit.enum';
 import { CategoryService } from './category.service';
 import { CreateServiceUseCase } from './use-cases/create-service.use-case';
 import { DeleteServiceUseCase } from './use-cases/delete-service.use-case';
@@ -58,7 +59,11 @@ export class ServicesService {
   async updateService(
     serviceId: number,
     userId: number,
-    updates: { price?: number; estimatedHours?: number | null },
+    updates: {
+      price?: number;
+      estimatedHours?: number | null;
+      timeUnit?: TimeUnit;
+    },
   ) {
     return this.updateServiceUseCase.execute(serviceId, userId, updates);
   }

--- a/services/src/services/services/use-cases/get-service-by-id.use-case.ts
+++ b/services/src/services/services/use-cases/get-service-by-id.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ServiceNotFoundException } from '../../../common/exceptions/services.exceptions';
 import { UsersClientService } from '../../../common/services/users-client.service';
 import { transformServicesWithOwners } from '../../../common/utils/service-transform.utils';
+import { ServiceHiringRepository } from '../../../service-hirings/repositories/service-hiring.repository';
 import { GetServiceByIdDto } from '../../dto/get-service-by-id.dto';
 import { ServiceRepository } from '../../repositories/service.repository';
 
@@ -10,28 +11,37 @@ export class GetServiceByIdUseCase {
   constructor(
     private readonly serviceRepository: ServiceRepository,
     private readonly usersClientService: UsersClientService,
+    private readonly serviceHiringRepository: ServiceHiringRepository,
   ) {}
 
   async execute(data: GetServiceByIdDto) {
     // Buscar el servicio con relaciones
     const service = await this.serviceRepository.findByIdWithRelations(data.id);
-    
+
     if (!service) {
       throw new ServiceNotFoundException(data.id);
     }
 
     // Obtener información del dueño del servicio
     const users = await this.usersClientService.getUsersByIds([service.userId]);
-    
+
     if (!users || users.length === 0) {
       throw new ServiceNotFoundException(data.id);
     }
+
+    // Obtener información de cotizaciones para el servicio
+    const quotationInfo =
+      await this.serviceHiringRepository.getQuotationInfoForServices(
+        [service.id],
+        data.currentUserId,
+      );
 
     // Transformar el servicio usando la función común
     const transformedServices = transformServicesWithOwners(
       [service],
       users,
       data.currentUserId,
+      quotationInfo,
     );
 
     // Retornar el primer (y único) servicio transformado

--- a/services/src/services/services/use-cases/get-services-by-user.use-case.ts
+++ b/services/src/services/services/use-cases/get-services-by-user.use-case.ts
@@ -3,6 +3,7 @@ import { UserNotFoundException } from '../../../common/exceptions/services.excep
 import { UsersClientService } from '../../../common/services/users-client.service';
 import { calculatePagination } from '../../../common/utils/pagination.utils';
 import { transformServicesWithOwners } from '../../../common/utils/service-transform.utils';
+import { ServiceHiringRepository } from '../../../service-hirings/repositories/service-hiring.repository';
 import { GetServicesByUserDto } from '../../dto/get-services-by-user.dto';
 import { ServiceRepository } from '../../repositories/service.repository';
 
@@ -11,6 +12,7 @@ export class GetServicesByUserUseCase {
   constructor(
     private readonly serviceRepository: ServiceRepository,
     private readonly usersClientService: UsersClientService,
+    private readonly serviceHiringRepository: ServiceHiringRepository,
   ) {}
 
   async execute(data: GetServicesByUserDto) {
@@ -34,11 +36,20 @@ export class GetServicesByUserUseCase {
       params.limit,
     );
 
+    // Obtener información de cotizaciones para los servicios
+    const serviceIds = services.map((service) => service.id);
+    const quotationInfo =
+      await this.serviceHiringRepository.getQuotationInfoForServices(
+        serviceIds,
+        data.currentUserId,
+      );
+
     // Transformar los servicios usando la función común
     const transformedServices = transformServicesWithOwners(
       services,
       users,
       data.currentUserId,
+      quotationInfo,
     );
 
     // Calcular información de paginación usando la función común

--- a/services/src/services/services/use-cases/update-service.use-case.ts
+++ b/services/src/services/services/use-cases/update-service.use-case.ts
@@ -5,6 +5,7 @@ import {
   ServiceNotOwnedByUserException,
 } from '../../../common/exceptions/services.exceptions';
 import { Service } from '../../entities/service.entity';
+import { TimeUnit } from '../../enums/time-unit.enum';
 import { ServiceRepository } from '../../repositories/service.repository';
 
 @Injectable()
@@ -14,7 +15,11 @@ export class UpdateServiceUseCase {
   async execute(
     serviceId: number,
     userId: number,
-    updates: { price?: number; estimatedHours?: number | null },
+    updates: {
+      price?: number;
+      estimatedHours?: number | null;
+      timeUnit?: TimeUnit;
+    },
   ): Promise<Service> {
     // Buscar el servicio por ID (incluyendo eliminados para validar si existe)
     const service =


### PR DESCRIPTION


- Added `quotationValidityDays` to `CreateQuotationDto` and `ServiceHiring` entity.
- Introduced `TimeUnit` enum for service time units (hours, days, weeks).
- Updated `CreateServiceDto` and `UpdateServiceDto` to include `timeUnit`.
- Enhanced service hiring operations to handle quotation expiration logic.
- Implemented methods to check and mark expired quotations in the repository.
- Updated service transformation logic to include quotation information.
- Adjusted SQL migration scripts to accommodate new columns and enum types.